### PR TITLE
Create sci-hub_newtab.bookmark.js

### DIFF
--- a/sci-hub_newtab.bookmark.js
+++ b/sci-hub_newtab.bookmark.js
@@ -1,0 +1,1 @@
+javascript: (function(){ window.open(location.origin.replace%28/%5Ehttps/, 'http') + '.sci-hub.tw' + location.pathname + location.search, '_blank')})();


### PR DESCRIPTION
Bookmark that opens the corresponding scihub page on a new tab. Useful for keeping the original page (IEEE, ACM etc.) on a different tab.